### PR TITLE
Fix missing GameState environment object

### DIFF
--- a/Uplink/Core/AppUtils.swift
+++ b/Uplink/Core/AppUtils.swift
@@ -20,6 +20,8 @@ enum Screen {
 class AppModel: ObservableObject {
     @Published var currentScreen: Screen = .login
     @Published var isGameLoaded: Bool = false
+    /// Shared game state accessible throughout the app
+    @Published var gameState: GameState = GameState.shared
     /*
      static func loadSavedUsernames()->[String] {
      if let names = UserDefaults.standard.array(forKey: "SavedUsernames") as? [String] {

--- a/Uplink/MainView.swift
+++ b/Uplink/MainView.swift
@@ -8,13 +8,13 @@
 import SwiftUI
 
 struct MainView: View {
-    @EnvironmentObject var gameState: GameState
+    @EnvironmentObject var appModel: AppModel
 
     var body: some View {
         ZStack(alignment: .top) {
             Color.black.ignoresSafeArea()
             VStack(alignment: .leading, spacing: 0) {
-                DateTime(gameState: gameState)
+                DateTime(gameState: appModel.gameState)
 //                if let system = gameState.connectedSystem {
 //                    TerminalView(system: system)
 //                } else {
@@ -28,5 +28,5 @@ struct MainView: View {
 }
 
 #Preview {
-    MainView().environmentObject(GameState.shared)
+    MainView().environmentObject(AppModel())
 }


### PR DESCRIPTION
## Summary
- access `GameState` through `AppModel`
- remove dedicated `GameState` environment object

## Testing
- `swift --version`
