### PR TITLE
Fix initial system setup and subclass init

### DIFF
--- a/Uplink/Core/GameState.swift
+++ b/Uplink/Core/GameState.swift
@@ -44,12 +44,14 @@ class GameState: ObservableObject {
         let home = System(
             name: SystemInfo.localHost.rawValue,
             ipAddress: SystemInfo.localHost.ipAddress,
-            introMessage: SystemInfo.localHost.welcomeMessage)
+            introMessage: SystemInfo.localHost.welcomeMessage,
+            services: [.terminal, .fileBrowser])
 
         let uplink = System(
             name: SystemInfo.uplinkPublicAccessMachine.rawValue,
             ipAddress: SystemInfo.uplinkPublicAccessMachine.ipAddress,
-            introMessage: SystemInfo.uplinkPublicAccessMachine.welcomeMessage)
+            introMessage: SystemInfo.uplinkPublicAccessMachine.welcomeMessage,
+            services: [.login, .missionBoard])
 
         availableSystems = [home, uplink]
     }

--- a/Uplink/Model/Company/CompanyUpload.swift
+++ b/Uplink/Model/Company/CompanyUpload.swift
@@ -19,6 +19,10 @@ class CompanyUplink: Company {
     override init(name: String = "Uplink", admin: String = "Uplink Admin", type: CompanyType = .commercial) {
         super.init(name: name, admin: admin, type: type)
     }
+
+    required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+    }
     
     func createMission(employer: Company, type: MissionType, title: String, payment: Int, description: String, snippet: String) {
         let newMission = Mission(


### PR DESCRIPTION
## Summary
- include services when creating initial `System` objects
- provide `required init(from:)` for `CompanyUplink`

## Testing
- `swiftc Uplink/Model/Company/Company.swift Uplink/Model/Company/CompanyUpload.swift Uplink/Model/Company/Mission.swift Uplink/Model/Company/Sale.swift Uplink/Model/Company/News.swift Uplink/Core/GameState.swift Uplink/Core/GameTicker.swift Uplink/Model/System.swift 2>&1 | head -n 20` *(fails: cannot find type 'ObservableObject' in scope)*