### PR TITLE
Add basic terminal and system list

### DIFF
--- a/Uplink/Core/GameState.swift
+++ b/Uplink/Core/GameState.swift
@@ -44,14 +44,25 @@ class GameState: ObservableObject {
         let home = System(
             name: SystemInfo.localHost.rawValue,
             ipAddress: SystemInfo.localHost.ipAddress,
-            introMessage: SystemInfo.localHost.welcomeMessage)
+            introMessage: SystemInfo.localHost.welcomeMessage,
+            securityLevel: 1,
+            knownUsers: ["root"])
 
         let uplink = System(
             name: SystemInfo.uplinkPublicAccessMachine.rawValue,
             ipAddress: SystemInfo.uplinkPublicAccessMachine.ipAddress,
-            introMessage: SystemInfo.uplinkPublicAccessMachine.welcomeMessage)
+            introMessage: SystemInfo.uplinkPublicAccessMachine.welcomeMessage,
+            securityLevel: 2,
+            knownUsers: ["admin"])
 
-        availableSystems = [home, uplink]
+        let academic = System(
+            name: SystemInfo.academicDatabase.rawValue,
+            ipAddress: SystemInfo.academicDatabase.ipAddress,
+            introMessage: SystemInfo.academicDatabase.welcomeMessage,
+            securityLevel: 3,
+            knownUsers: ["guest", "admin"])
+
+        availableSystems = [home, uplink, academic]
     }
 
     func printSummary() {
@@ -59,7 +70,7 @@ class GameState: ObservableObject {
         print("Player: \(player.name) | Credits: \(player.credits)")
         print("Available Systems:")
         for sys in availableSystems {
-            print(" - \(sys.name) (\(sys.ipAddress))")
+            print(" - \(sys.name) (\(sys.ipAddress)) | Security: \(sys.securityLevel)")
         }
         print("Company: \(uplinkCompany.name)")
         print("Current Game Time: \(currentGameTime)")

--- a/Uplink/MainView.swift
+++ b/Uplink/MainView.swift
@@ -15,13 +15,11 @@ struct MainView: View {
             Color.black.ignoresSafeArea()
             VStack(alignment: .leading, spacing: 0) {
                 DateTime(gameState: appModel.gameState)
-//                if let system = gameState.connectedSystem {
-//                    TerminalView(system: system)
-//                } else {
-//                    Text("No system connected")
-//                        .foregroundColor(.gray)
-//                        .padding()
-//                }
+                if let system = appModel.gameState.connectedSystem {
+                    TerminalView(system: system)
+                } else {
+                    SystemListView(gameState: appModel.gameState)
+                }
             }
         }
     }

--- a/Uplink/Model/System.swift
+++ b/Uplink/Model/System.swift
@@ -13,25 +13,34 @@ struct System: Identifiable, Codable {
     let ipAddress: String
     let introMessage: String
     let services: [SystemService]
+    var securityLevel: Int
+    var knownUsers: [String]
     var savedUsernames: [String]
     
-    init(name: String, ipAddress: String, introMessage: String, services: [SystemService], savedUsernames: [String] = []) {
+    init(name: String,
+         ipAddress: String,
+         introMessage: String,
+         services: [SystemService] = [.terminal],
+         securityLevel: Int = 1,
+         knownUsers: [String] = [],
+         savedUsernames: [String] = []) {
         self.id = UUID()
         self.name = name
         self.ipAddress = ipAddress
         self.introMessage = introMessage
         self.services = services
+        self.securityLevel = securityLevel
+        self.knownUsers = knownUsers
         self.savedUsernames = savedUsernames
     }
-}
-
-extension System {
     init(from computer: Computer) {
         self.id = UUID()
         self.name = computer.name
         self.ipAddress = computer.ipAddress
         self.introMessage = "Welcome to \(computer.name)."
         self.services = Computer.defaultServices(for: computer)
+        self.securityLevel = 1
+        self.knownUsers = []
         self.savedUsernames = []
     }
 }

--- a/Uplink/UI/Views/SystemListView.swift
+++ b/Uplink/UI/Views/SystemListView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct SystemListView: View {
+    @ObservedObject var gameState: GameState
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("Available Systems")
+                .uplinkHeadline()
+                .padding()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    ForEach(gameState.availableSystems) { system in
+                        Button(action: { gameState.connectedSystem = system }) {
+                            SystemChip(system: system)
+                        }
+                        .buttonStyle(PlainButtonStyle())
+                    }
+                }
+                .padding()
+            }
+        }
+    }
+}
+
+#Preview {
+    SystemListView(gameState: GameState())
+}

--- a/Uplink/UI/Views/TerminalView.swift
+++ b/Uplink/UI/Views/TerminalView.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+
+struct TerminalView: View {
+    @StateObject private var session: TerminalSession
+    @State private var log: [String] = []
+    @State private var command: String = ""
+
+    init(system: System) {
+        _session = StateObject(wrappedValue: TerminalSession(system: system))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 4) {
+                        ForEach(Array(log.enumerated()), id: \.offset) { index, line in
+                            Text(line)
+                                .bodyText()
+                                .id(index)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .background(Color.black)
+                .onChange(of: log.count) { _ in
+                    proxy.scrollTo(log.count - 1, anchor: .bottom)
+                }
+            }
+            HStack {
+                TerminalTextField(placeholder: "command", text: $command)
+                TerminalButton(text: "Send") { handleCommand() }
+            }
+        }
+        .padding()
+        .onAppear {
+            log.append("Welcome to \(session.currentSystem.name)")
+            log.append(session.currentSystem.introMessage)
+            log.append("Type 'help' for commands.")
+        }
+    }
+
+    private func handleCommand() {
+        let trimmed = command.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return }
+        log.append("> \(trimmed)")
+        command = ""
+
+        switch trimmed.lowercased() {
+        case "help":
+            log.append("Available commands: scan, connect [ip], help")
+        case "scan":
+            let list = GameState.shared.availableSystems
+                .map { "\($0.ipAddress) (\($0.name))" }
+                .joined(separator: "\n")
+            log.append(list)
+        case let cmd where cmd.starts(with: "connect"):
+            let parts = cmd.split(separator: " ")
+            guard parts.count > 1 else {
+                log.append("Usage: connect [ip]")
+                return
+            }
+            let ip = String(parts[1])
+            if let target = GameState.shared.availableSystems.first(where: { $0.ipAddress == ip }) {
+                GameState.shared.connectedSystem = target
+                session.currentSystem = target
+                log.append("Connected to \(target.name)")
+                log.append(target.introMessage)
+            } else {
+                log.append("Host not found")
+            }
+        default:
+            log.append("Unknown command")
+        }
+    }
+}
+
+#Preview {
+    TerminalView(system: GameState().availableSystems.first!)
+}


### PR DESCRIPTION
## Summary
- extend `System` with security level and known users
- set up three mock systems in `GameState`
- show a list of available systems and allow connecting
- add interactive `TerminalView` with simple commands
- swap `MainView` to show `TerminalView` when connected
- remove `System` extension initializer to follow code style

## Testing
- `git status --short`
