### PR TITLE
Add SystemMessage data model

### DIFF
--- a/Uplink/Model/SystemMessage.swift
+++ b/Uplink/Model/SystemMessage.swift
@@ -1,0 +1,39 @@
+//
+//  SystemMessage.swift
+//  Uplink
+//
+//  Created by Codex.
+//
+
+import Foundation
+
+struct SystemMessage: Identifiable, Codable {
+    let id: UUID
+    let fromSystem: System
+    let toPlayer: String
+    var subject: String
+    var body: String
+    var date: Date
+    var delivered: Bool
+    var read: Bool
+
+    init(
+        from system: System,
+        to player: String,
+        subject: String,
+        body: String,
+        date: Date = Date(),
+        delivered: Bool = false,
+        read: Bool = false
+    ) {
+        self.id = UUID()
+        self.fromSystem = system
+        self.toPlayer = player
+        self.subject = subject
+        self.body = body
+        self.date = date
+        self.delivered = delivered
+        self.read = read
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a `SystemMessage` struct to model a message from a system to a player

## Testing
- `swift build` *(fails: `Could not find Package.swift`)*
- `xcodebuild -list -project Uplink.xcodeproj` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6844cc941724833182317082795849f2